### PR TITLE
[DCS-388] Hermes can now run in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM qa.stratio.com/stratio/ubuntu-base-ssh:16.04
+MAINTAINER stratio
+COPY target/hermes-*-allinone.jar /hermes.jar
+COPY docker/docker-entrypoint.sh /
+COPY src/main/resources/application.conf /
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('libpipelines@feature/multibranch') _
+@Library('libpipelines@master') _
 
 hose {
     EMAIL = 'qa'

--- a/README.md
+++ b/README.md
@@ -37,3 +37,6 @@ decimal(2,negative) #=> -45.89
 decimal(2,4) #=> 45.7568
 
 decimal(3,2,positive) #=> 354.89
+
+###Cluster
+

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -xe
+
+if [[ -z  ${REMOTE_NETTY_TCP_PORT} ]]; then
+  echo "Error: env variable REMOTE_NETTY_TCP_PORT is not defined." 
+fi
+
+PARAMS="-Dakka.remote.netty.tcp.port=${REMOTE_NETTY_TCP_PORT}"
+
+
+if [[ ! -z  ${CLUSTER_SEED_NODES} ]]; then
+  PARAMS="${PARAMS} -Dakka.cluster.seed-nodes.0=${CLUSTER_SEED_NODES}"
+fi
+
+echo "Params: ${PARAMS}"
+java -jar ${PARAMS} /hermes.jar
+
+tail -F /var/log/sds/hermes/hermes.log

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,17 +1,22 @@
 akka {
   loglevel = "INFO"
-  actor.provider = "akka.cluster.ClusterActorRefProvider"
+  actor {
+    provider = "akka.cluster.ClusterActorRefProvider"
+    debug {
+      receive = on
+      lifecycle = on
+    }
+  }
   remote {
     log-remote-lifecycle-events = off
     netty.tcp {
-      hostname = "127.0.0.1"
+      hostname = ${clustering.ip}
       port = 2551
     }
   }
   cluster {
     roles = [backend]
-    seed-nodes = [
-      "akka.tcp://hermes@127.0.0.1:2551"
-    ]
+    seed-nodes = [${?VALUE}]
+    auto-down-unreachable-after = 10s
   }
 }

--- a/src/test/scala/com/stratio/hermes/implicits/HermesImplicitsTest.scala
+++ b/src/test/scala/com/stratio/hermes/implicits/HermesImplicitsTest.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.hermes.implicits
+
+import org.junit.runner.RunWith
+import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class HermesImplicitsTest extends FlatSpec with Matchers {
+
+  "A HermesImplicit" should "get a valid IP of a host" in {
+    import com.stratio.hermes.implicits.HermesImplicits._
+    getHostIP() should fullyMatch regex """.*(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3}).*"""
+  }
+}


### PR DESCRIPTION
## Description
Now, it is possible to run Hermes creating an Akka cluster running inside Docker containers.

### Testing
Follow the next steps to create a cluster:
   * Create the docker image "hermes": $ mvn clean package; docker build -t hermes .
   * Run the seed node: $ docker run --name hermes-seed -e REMOTE_NETTY_TCP_PORT=2551 -e CLUSTER_SEED_NODES=akka.tcp://hermes@172.17.0.2:2551 hermes
   * Run a cluster node: $ docker run --name hermes-node -e REMOTE_NETTY_TCP_PORT=2551 -e CLUSTER_SEED_NODES=akka.tcp://hermes@172.17.0.2:2551 hermes
   * Now you can play to shutdown the node or the seed and see what happen in the logs.
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Coverage (>90%)

### Documentation
- [ ] Changelog update
- [ ] Documentation entry

### Scalastyle
Result of scalastyle execution: All OK

