### PR TITLE
[DCS-153] Condition to log only when there are parsing errors

### DIFF
--- a/src/main/scala/com/stratio/hermes/utils/Hermes.scala
+++ b/src/main/scala/com/stratio/hermes/utils/Hermes.scala
@@ -182,7 +182,7 @@ case class Hermes(locale: String = HermesConstants.ConstantDefaultLocale) extend
         val geoModelAndErrors: List[Either[String, Seq[GeoModel]]] = (for {
           filename <- fileNames
         } yield parser(filename)).toList
-        log.warn(s"${parseErrorList(geoModelAndErrors)}")
+        if (parseErrorList(geoModelAndErrors).nonEmpty) log.warn(s"${parseErrorList(geoModelAndErrors)}")
         geoModelAndErrors
       }
       case localeMatch => List(parser(s"$localeMatch.json"))
@@ -212,11 +212,7 @@ case class Hermes(locale: String = HermesConstants.ConstantDefaultLocale) extend
       l.filter(_.isLeft).map(_.left.toOption.get)
     }
   }
-
 }
-
 sealed trait NumberSign
-
 case object Positive extends NumberSign
-
 case object Negative extends NumberSign


### PR DESCRIPTION
## Description
Condition to log only when there are parsing errors

### Testing
- [X] Unit, integration, acceptance tests as appropriate
- [X] Coverage (>90%)

### Documentation
- [x] Changelog update
- [X] Documentation entry

### Scalastyle
Result of scalastyle execution: 
Processed 18 file(s)
Found 0 errors
Found 0 warnings
Found 0 infos
