### PR TITLE
[DCS-2049] Messages generation throttle valve

### DIFF
--- a/seed_debug
+++ b/seed_debug
@@ -1,0 +1,1 @@
+java -jar -Dhermes.client=true -Dakka.remote.hostname=localhost -Dakka.remote.netty.tcp.port=2552 -Dakka.remote.netty.tcp.hostname=localhost -Dakka.cluster.seed-nodes.0=akka.tcp://hermes@localhost:2552 -agentlib:jdwp=transport=dt_socket,address=9999,server=y,suspend=y target/hermes-0.2.0-SNAPSHOT-allinone.jar

--- a/src/main/scala/com/stratio/hermes/actors/HermesSupervisorActor.scala
+++ b/src/main/scala/com/stratio/hermes/actors/HermesSupervisorActor.scala
@@ -28,6 +28,7 @@ import org.apache.avro.Schema.Parser
 import play.twirl.api.Txt
 import tech.allegro.schema.json2avro.converter.JsonAvroConverter
 
+import scala.annotation.tailrec
 import scala.util.Try
 
 /**
@@ -69,23 +70,20 @@ class HermesSupervisorActor(implicit config: Config) extends Actor with ActorLog
     case HermesSupervisorActor.List(ids) =>
       log.debug("Received list message")
       execute(ids, () => {
-          val status = hermesExecutor.map(_.status).getOrElse(false)
-          sender ! s"$id | $status"
+        val status = hermesExecutor.map(_.status).getOrElse(false)
+        sender ! s"$id | $status"
       })
   }
-
-  /////////////////////////// XXX Protected methods. ///////////////////////////
 
   protected[this] def isAMessageForMe(ids: Seq[String]): Boolean = ids.exists(x => id == x)
 
   protected[this] def execute(ids: Seq[String], callback: () => Unit): Unit =
     if(ids.nonEmpty && !isAMessageForMe(ids)) log.debug("Is not a message for me!") else callback()
-
 }
 
 /**
  * Thread that will generate data and it is controlled by the supervisor thanks to stopExecutor method.
- * @param hc with the Hermes' config.
+ * @param hc with the Hermes' configuration.
  * @param config with general configuration.
  */
 class HermesExecutor(hc: HermesConfig)(implicit config: Config) extends HermesExecutable with HermesLogging {
@@ -93,12 +91,17 @@ class HermesExecutor(hc: HermesConfig)(implicit config: Config) extends HermesEx
   val converter = new JsonAvroConverter()
   var running: Boolean = false
 
+  /**
+   * Starts the thread.
+   * @param hc with all configuration needed to start the thread.
+   */
   override def start(hc: HermesConfig): Unit = run()
 
   override def stopExecutor: Unit = running = false
 
   def status: Boolean = running
 
+  //scalastyle:off
   override def run(): Unit = {
     running = true
     val kafkaClient = new KafkaClient[Object](hc.kafkaConfig)
@@ -107,16 +110,61 @@ class HermesExecutor(hc: HermesConfig)(implicit config: Config) extends HermesEx
 
     val parserOption = hc.avroSchema.map(new Parser().parse(_))
 
-    while(running) {
-      val json = template.static(hermes).toString()
-      parserOption match {
-        case None =>
-          kafkaClient.send(hc.topic, json)
-        case Some(value) =>
-          val record = converter.convertToGenericDataRecord(json.getBytes("UTF-8"), value)
-          kafkaClient.send(hc.topic, record)
+    val timeoutNumberOfEventsOption = hc.timeoutNumberOfEventsOption
+    val timeoutNumberOfEventsDurationOption = hc.timeoutNumberOfEventsDurationOption
+    val stopNumberOfEventsOption = hc.stopNumberOfEventsOption
+
+    /**
+     * If you are defining the following example configuration:
+     * timeout-rules {
+     *   number-of-events: 1000
+     *   duration: 2 seconds
+     * }
+     * Then when the node produces 1000 events, it will wait 2 seconds to start producing again.
+     * @param numberOfEvents with the current number of events generated.
+     */
+    def performTimeout(numberOfEvents: Int): Unit =
+      for {
+        timeoutNumberOfEvents <- timeoutNumberOfEventsOption
+        timeoutNumberOfEventsDuration <- timeoutNumberOfEventsDurationOption
+        if(numberOfEvents % timeoutNumberOfEvents == 0)
+      } yield ({
+        log.debug(s"Sleeping executor thread $timeoutNumberOfEventsDuration")
+        Thread.sleep(timeoutNumberOfEventsDuration.toMillis)
+      })
+
+    /**
+     * Starts to generate events in a recursive way.
+     * Note that this generation only will stop in two cases:
+     *   1. The user sends an stop event to the supervisor actor; the supervisor change the state of running to false,
+     *      stopping the execution.
+     *   2. The user defines the following Hermes' configuration:
+     *      stop-rules {
+     *         number-of-events: 5000
+     *      }
+     *      In this case only it will generate 5000 events, then automatically the thread puts its state of running to
+     *      false stopping the event generation.
+     * @param numberOfEvents with the current number of events generated.
+     */
+    @tailrec
+    def recursiveGeneration(numberOfEvents: Int): Unit =
+      if(running) {
+        log.debug(s"$numberOfEvents")
+        val json = template.static(hermes).toString()
+        parserOption match {
+          case None =>
+            kafkaClient.send(hc.topic, json)
+            performTimeout(numberOfEvents)
+
+          case Some(value) =>
+            val record = converter.convertToGenericDataRecord(json.getBytes("UTF-8"), value)
+            kafkaClient.send(hc.topic, record)
+            performTimeout(numberOfEvents)
+        }
+        if(stopNumberOfEventsOption.filter(_ == numberOfEvents).map(_ => stopExecutor).isEmpty)
+          recursiveGeneration(numberOfEvents + 1)
       }
-    }
+    recursiveGeneration(0)
   }
 }
 
@@ -125,15 +173,12 @@ trait HermesExecutable extends Thread {
   def start(hc: HermesConfig)
   def stopExecutor
   def status: Boolean
-
 }
 
 object HermesSupervisorActor {
 
   case class Start(workerIds: Seq[String], hermesConfig: HermesConfig)
-
   case class Stop(workerIds: Seq[String])
-
   case class List(workerIds: Seq[String])
 
   object WorkerStatus extends Enumeration {

--- a/src/main/scala/com/stratio/hermes/helpers/HermesConfig.scala
+++ b/src/main/scala/com/stratio/hermes/helpers/HermesConfig.scala
@@ -19,6 +19,8 @@ package com.stratio.hermes.helpers
 import com.stratio.hermes.constants.HermesConstants
 import com.stratio.hermes.helpers.HermesConfig._
 import com.typesafe.config.ConfigFactory
+import java.time.Duration
+
 
 import scala.util.Try
 
@@ -68,6 +70,12 @@ case class HermesConfig(hermesConfigContent: String,
   def templateContent: String = template
 
   def hermesI18n: String = hermesConfig.getString("hermes.i18n")
+
+  def timeoutNumberOfEventsOption: Option[Int] = Try(hermesConfig.getInt("hermes.timeout-rules.number-of-events")).toOption
+
+  def timeoutNumberOfEventsDurationOption: Option[Duration] = Try(hermesConfig.getDuration("hermes.timeout-rules.duration")).toOption
+
+  def stopNumberOfEventsOption: Option[Int] = Try(hermesConfig.getInt("hermes.stop-rules.number-of-events")).toOption
 
 }
 

--- a/src/main/scala/com/stratio/hermes/helpers/HermesConsoleHelper.scala
+++ b/src/main/scala/com/stratio/hermes/helpers/HermesConsoleHelper.scala
@@ -19,7 +19,7 @@ package com.stratio.hermes.helpers
 import com.stratio.hermes.actors.HermesClientActor
 import jline.console.ConsoleReader
 
-case class HermesConsoleHelper(client: HermesClientActor){
+case class HermesConsoleHelper(client: HermesClientActor) {
 
   lazy val reader = createDefaultReader()
 
@@ -100,6 +100,14 @@ case class HermesConsoleHelper(client: HermesClientActor){
     val ids = line.replace(firstWord, "").trim.split(",").map(_.trim).filter("" != _)
     ids.map(id => println(s"Sending $id start message"))
     client.start(hermesConfig, kafkaConfig, template, avroConfig, ids)
+    firstWord match {
+      case "start" =>
+        ids.map(id => println(s"Sending $id start message"))
+        client.start(hermesConfig, kafkaConfig, template, avroConfig, ids)
+      case "stop" =>
+        ids.map(id => println(s"Sending $id stop message"))
+        client.stop(ids)
+    }
     reader.setPrompt("hermes> ")
   }
 

--- a/src/main/scala/com/stratio/hermes/helpers/HermesRunnerHelper.scala
+++ b/src/main/scala/com/stratio/hermes/helpers/HermesRunnerHelper.scala
@@ -67,6 +67,15 @@ object HermesRunnerHelper extends HermesLogging {
       |  topic = "alicia"
       |  template-name = "chustasTemplate"
       |  i18n = "ES"
+      |
+      |  timeout-rules {
+      |    number-of-events: 1000
+      |    duration: 2 seconds
+      |  }
+      |
+      |  stop-rules {
+      |    number-of-events: 5000
+      |  }
       |}
     """.stripMargin
 


### PR DESCRIPTION
## Description
Now we can to set timeouts when a node produces N messages or even stop its execution if also it had produced M messages. The configuration about these new features is showed in the next lines:

```
hermes {
  templates-path = "/tmp/hermes/templates"
  topic = "topic1"
  template-name = "templatename"
  i18n = "ES"
  timeout-rules {
    number-of-events: 1000
    duration: 2 seconds
  }
  stop-rules {
    number-of-events: 5000
  }
}
```
### Testing
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Coverage (>90%)

### Documentation
- [ ] Changelog update
- [ ] Documentation entry

### Scalastyle
Result of scalastyle execution: 
