### PR TITLE
[Khermes #48]Multiple configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,12 @@ Steps to run a policy:
   }
 ```
   As you can see you should configure the following variables:
-    - templates-path: in every node that you send this configuration, it will need to generate and compile a template.
-    - topic: it indicates a Kafka topic where messages will be produced.
-    - template-name: it indicates a prefix for the generated .scala and .class files. It is possible that in the future this variable dissapears.
-    - i18n: internationalization of Khermes helper. It generates, for example names in Spanish. Right now only ES and EN are available.
-    - timeout-rules: it is optional. When it is set it generates 1000 events and wait 2 seconds to generate the next 1000 events.
-    - stop-rules: it is optional. When it is set it generates 5000 events and the node stops data generation. Besides the node will be free to accept more requests.
+  - templates-path: in every node that you send this configuration, it will need to generate and compile a template.
+  - topic: it indicates a Kafka topic where messages will be produced.
+  - template-name: it indicates a prefix for the generated .scala and .class files. It is possible that in the future this variable dissapears.
+  - i18n: internationalization of Khermes helper. It generates, for example names in Spanish. Right now only ES and EN are available.
+  - timeout-rules: it is optional. When it is set it generates 1000 events and wait 2 seconds to generate the next 1000 events.
+  - stop-rules: it is optional. When it is set it generates 5000 events and the node stops data generation. Besides the node will be free to accept more requests.
     
 * Step 2) Save a Kafka configuration that will also be persisted in Zookeeper.
 ```

--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ Right now the only way  to execute Khermes is to generate a jar file. To make it
 ```sh
 $ mvn clean package
 ```
-This command will generate a fat jar with all dependencies in target/hermes-<version>.jar. To run it, you should execute:
+This command will generate a fat jar with all dependencies in target/khermes-<version>.jar. To run it, you should execute:
 ```sh
-$ java -jar target/hermes-<version>.jar [-Dparameters.to.overwrite]
+$ java -jar target/khermes-<version>.jar [-Dparameters.to.overwrite]
 ```
 
 ## Getting started.
 The first thing that you should do is to specify a configuration. Khermes configuration is done thanks to Typesafe config.
 You can see all options that you can configure in the next section:
 ```
-hermes {
-  templates-path = "/opt/hermes/templates"
+khermes {
+  templates-path = "/opt/khermes/templates"
   client = false
 }
 akka {
@@ -89,24 +89,38 @@ If you execute help in your command line you can see the list of available comma
 
 ```
 khermes> help
-Khermes commands:
-  set khermes             Sets your Khermes configuration
-  set kafka              Sets your Kafka configuration
-  set template           Sets your template
-  set avro               Sets your Avro configuration
-  show config            Show all set configurations
-  ls                     Lists the nodes with their current status
-  start <node-id>        Starts event generation in node with id <node-id>
-  stop <node-id>         Stops event generation in node with id <node-id>
-  clear                  Cleans the screen.
-  help                   Shows this help.
-  exit                   Exit of Khermes Cli.
+Khermes client provide the next commands to manage your Khermes cluster:
+  Usage: COMMAND [args...]
+
+  Commands:
+     start [command options] : Starts event generation in N nodes.
+       -h, --khermes    : Khermes configuration
+       -k, --kafka      : Kafka configuration
+       -t, --template   : Template to generate data
+       -a, --avro       : Avro configuration
+       -i, --ids        : Node id where start khermes
+     stop [command options] : Stop event generation in N nodes.
+       -i, --ids        : Node id where start khermes
+     ls                    : List the nodes with their current status
+     save [command options] : Save your configuration in zookeeper
+       -h, --khermes    : Khermes configuration
+       -k, --kafka      : Kafka configuration
+       -t, --template   : Template to generate data
+       -a, --avro       : Avro configuration
+     show [command options] : Show your configuration
+       -h, --khermes    : Khermes configuration
+       -k, --kafka      : Kafka configuration
+       -t, --template   : Template to generate data
+       -a, --avro       : Avro configuration
+     clear                 : Clean the screen.
+     help                  : Print this usage.
+     exit | quit | bye     : Exit of Khermes Cli.   
 ```
 
 Steps to run a policy:
 * Step 1) Save a Khermes configuration that will be persisted in Zookeeper. This is needed because otherwise, the next time that the user executes Khermes it will lost this configuration:
 ```
-  khermes> set khermes
+  khermes> save --khermes nameKhermesConfig
   Press Control + D to finish
   khermes {
      templates-path = "/tmp/khermes/templates"
@@ -132,7 +146,7 @@ Steps to run a policy:
     
 * Step 2) Save a Kafka configuration that will also be persisted in Zookeeper.
 ```
-  khermes> set kafka
+  khermes> save --kafka nameKafkaConfig
   Press Control + D to finish
   kafka {
      bootstrap.servers = "localhost:9092"
@@ -144,7 +158,7 @@ Steps to run a policy:
   
 * Step 3) Save a Twirl template that will also be persisted in Zookeeper.
 ```
-  khermes> set template
+  khermes> save --template nameTemplate
   Press Control + D to finish
   @import com.stratio.hermes.utils.Hermes
   @(khermes: Khermes)
@@ -156,11 +170,11 @@ Steps to run a policy:
 ```
   khermes> ls
   Node Id                                Status
-  845441ec-cb0d-4363-b494-a39d56a82727 | false
-  khermes> start 845441ec-cb0d-4363-b494-a39d56a82727
+  845441eccb0d4363b494a39d56a82727 | false
+  khermes> start --kafka nameKafkaConfig --template nameTemplate --khermes nameKhermesConfig --ids 845441eccb0d4363b494a39d56a82727
   khermes> ls
   Node Id                                Status
-  845441ec-cb0d-4363-b494-a39d56a82727 | true
+  845441eccb0d4363b494a39d56a82727 | true
 ```
   At this moment the node with id 845441ec-cb0d-4363-b494-a39d56a82727 is producing messages to Kafka following the saved template. You can check it using Kafka console consumer.
 
@@ -204,11 +218,11 @@ Based on [Faker](https://github.com/stympy/faker) we are developing a random gen
 ## Docker.
 * Seed + Node
 ```sh
-  docker run -dit --name SEED_NAME -e PARAMS="-Dhermes.client=true -Dakka.remote.hostname=SEED_NAME.DOMAIN -Dakka.remote.netty.tcp.port=2552 -Dakka.remote.netty.tcp.hostname=SEED_NAME.DOMAIN -Dakka.cluster.seed-nodes.0=akka.tcp://hermes@SEED_NAME.DOMAIN:2552" qa.stratio.com/stratio/hermes:VERSION
+  docker run -dit --name SEED_NAME -e PARAMS="-Dkhermes.client=true -Dakka.remote.hostname=SEED_NAME.DOMAIN -Dakka.remote.netty.tcp.port=2552 -Dakka.remote.netty.tcp.hostname=SEED_NAME.DOMAIN -Dakka.cluster.seed-nodes.0=akka.tcp://khermes@SEED_NAME.DOMAIN:2552" qa.stratio.com/stratio/khermes:VERSION
 ```
 * Node
 ```sh
-  docker run -dit --name AGENT_NAME -e PARAMS="-Dhermes.client=false -Dakka.remote.hostname=AGENT_NAME.DOMAIN -Dakka.remote.netty.tcp.port=2553 -Dakka.cluster.seed-nodes.0=akka.tcp://hermes@SEED_NAME.DOMAIN:2552" qa.stratio.com/stratio/hermes:VERSION
+  docker run -dit --name AGENT_NAME -e PARAMS="-Dkhermes.client=false -Dakka.remote.hostname=AGENT_NAME.DOMAIN -Dakka.remote.netty.tcp.port=2553 -Dakka.cluster.seed-nodes.0=akka.tcp://khermes@SEED_NAME.DOMAIN:2552" qa.stratio.com/stratio/khermes:VERSION
 ```
   
 ## FAQ.

--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ If you execute help in your command line you can see the list of available comma
 
 ```
 khermes> help
-Khermes client provide the next commands to manage your Khermes cluster:
+Khermes client provides the next commands to manage your Khermes cluster:
   Usage: COMMAND [args...]
 
   Commands:
      start [command options] : Starts event generation in N nodes.
-       -h, --khermes    : Khermes configuration
-       -k, --kafka      : Kafka configuration
+       -kh, --khermes    : Khermes configuration
+       -ka, --kafka      : Kafka configuration
        -t, --template   : Template to generate data
        -a, --avro       : Avro configuration
        -i, --ids        : Node id where start khermes
@@ -103,13 +103,13 @@ Khermes client provide the next commands to manage your Khermes cluster:
        -i, --ids        : Node id where start khermes
      ls                    : List the nodes with their current status
      save [command options] : Save your configuration in zookeeper
-       -h, --khermes    : Khermes configuration
-       -k, --kafka      : Kafka configuration
+       -kh, --khermes    : Khermes configuration
+       -ka, --kafka      : Kafka configuration
        -t, --template   : Template to generate data
        -a, --avro       : Avro configuration
      show [command options] : Show your configuration
-       -h, --khermes    : Khermes configuration
-       -k, --kafka      : Kafka configuration
+       -kh, --khermes    : Khermes configuration
+       -ka, --kafka      : Kafka configuration
        -t, --template   : Template to generate data
        -a, --avro       : Avro configuration
      clear                 : Clean the screen.

--- a/src/main/scala/com/stratio/khermes/actors/KhermesSupervisorActor.scala
+++ b/src/main/scala/com/stratio/khermes/actors/KhermesSupervisorActor.scala
@@ -44,7 +44,8 @@ class KhermesSupervisorActor(implicit config: Config) extends Actor with ActorLo
   mediator ! Subscribe("content", self)
 
   var khermesExecutor: Option[KhermesExecutor] = None
-  val id = UUID.randomUUID.toString
+  //TODO Temporal until a better implementation of parsing arguments
+  val id = UUID.randomUUID.toString.replace("-","")
 
   val khermes = Khermes(Try(config.getString("khermes.i18n")).toOption.getOrElse("EN"))
 

--- a/src/main/scala/com/stratio/khermes/helpers/ArgsParser.scala
+++ b/src/main/scala/com/stratio/khermes/helpers/ArgsParser.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.khermes.helpers
+
+class ArgsParser {
+  def commandWord(line: String):String={
+    line.split(" ").head
+  }
+  def parse(line: String): Map[String, List[String]] ={
+    val splitWords = line.split("-").filter(x => x != "")
+    val filterFirstWord= splitWords.drop(1)
+    val options = filterFirstWord.map(x => x.split("\\W+"))
+    val result = options.map(c => c.head -> c.tail.toList)
+    result.toMap
+  }
+}

--- a/src/main/scala/com/stratio/khermes/helpers/ArgsParser.scala
+++ b/src/main/scala/com/stratio/khermes/helpers/ArgsParser.scala
@@ -16,12 +16,13 @@
 package com.stratio.khermes.helpers
 
 class ArgsParser {
-  def commandWord(line: String):String={
+  def commandWord(line: String): String = {
     line.split(" ").head
   }
-  def parse(line: String): Map[String, List[String]] ={
+
+  def parseArgsValues(line: String): Map[String, List[String]] = {
     val splitWords = line.split("-").filter(x => x != "")
-    val filterFirstWord= splitWords.drop(1)
+    val filterFirstWord = splitWords.drop(1)
     val options = filterFirstWord.map(x => x.split("\\W+"))
     val result = options.map(c => c.head -> c.tail.toList)
     result.toMap

--- a/src/main/scala/com/stratio/khermes/helpers/KhermesConsoleHelper.scala
+++ b/src/main/scala/com/stratio/khermes/helpers/KhermesConsoleHelper.scala
@@ -17,113 +17,91 @@
 package com.stratio.khermes.helpers
 
 import com.stratio.khermes.actors.KhermesClientActor
-import com.stratio.khermes.constants.KhermesConstants
+import com.stratio.khermes.constants.KhermesConstants._
 import com.stratio.khermes.implicits.KhermesImplicits.khermesConfigDAO
 import jline.console.ConsoleReader
 
-
-import scala.util.{Success, Failure, Try}
+import scala.util.{Failure, Success, Try}
 
 case class KhermesConsoleHelper(client: KhermesClientActor) {
 
   lazy val reader = createDefaultReader()
-
-  parseLines(
-    firstLoad(KhermesConstants.KhermesConfigNodePath),
-    firstLoad(KhermesConstants.KafkaConfigNodePath),
-    firstLoad(KhermesConstants.TemplateNodePath),
-    firstLoad(KhermesConstants.AvroConfigNodePath)
-  )
+  lazy val argsParser = new ArgsParser
 
   //scalastyle:off
-  def parseLines(khermesConfig: Option[String] = None,
-                 kafkaConfig: Option[String] = None,
-                 template: Option[String] = None,
-                 avroConfig: Option[String] = None): Unit = {
+  def parseLines: Unit = {
     reader.readLine.trim match {
-      case "set khermes" =>
-        val config = setConfiguration(khermesConfig, kafkaConfig, template, avroConfig)
-        khermesConfigDAO.saveConfig(KhermesConstants.KhermesConfigNodePath, config.get)
-        parseLines(config, kafkaConfig, template, avroConfig)
+      case value if value.startsWith("save") =>
+        KhermesConsoleHelper.save(argsParser.parse(value), argsParser.commandWord(value), this.setConfiguration())
+        parseLines
 
-      case "set kafka" =>
-        val config = setConfiguration(khermesConfig, kafkaConfig, template, avroConfig)
-        khermesConfigDAO.saveConfig(KhermesConstants.KafkaConfigNodePath, config.get)
-        parseLines(khermesConfig, config, template, avroConfig)
-
-      case "set template" =>
-        val config = setConfiguration(khermesConfig, kafkaConfig, template, avroConfig)
-        khermesConfigDAO.saveConfig(KhermesConstants.TemplateNodePath, config.get)
-        parseLines(khermesConfig, kafkaConfig, config, avroConfig)
-
-      case "set avro" =>
-        val config = setConfiguration(khermesConfig, kafkaConfig, template, avroConfig)
-        khermesConfigDAO.saveConfig(KhermesConstants.AvroConfigNodePath, config.get)
-        parseLines(khermesConfig, kafkaConfig, template, config)
+      case value if value.startsWith("show") =>
+        println(KhermesConsoleHelper.show(argsParser.parse(value), argsParser.commandWord(value)))
+        parseLines
 
       case value if value.startsWith("start") =>
-        startStop(value, "start", khermesConfig, kafkaConfig, template, avroConfig)
-        parseLines(khermesConfig, kafkaConfig, template, avroConfig)
+        start(argsParser.parse(value), argsParser.commandWord(value))
+        parseLines
 
       case value if value.startsWith("stop") =>
-        startStop(value, "stop", khermesConfig, kafkaConfig, template, avroConfig)
-        parseLines(khermesConfig, kafkaConfig, template, avroConfig)
+        stop(argsParser.parse(value), argsParser.commandWord(value))
+        parseLines
 
       case "ls" =>
         ls
-        parseLines(khermesConfig, kafkaConfig, template, avroConfig)
-
-      case "show config" =>
-        showConfig(khermesConfig, kafkaConfig, template, avroConfig)
-        parseLines(khermesConfig, kafkaConfig, template, avroConfig)
+        parseLines
 
       case "help" =>
-        help
-        parseLines(khermesConfig, kafkaConfig, template, avroConfig)
+        println(KhermesConsoleHelper.help)
+        parseLines
 
       case "clear" =>
         clearScreen
-        parseLines(khermesConfig, kafkaConfig, template, avroConfig)
+        parseLines
 
       case "exit" | "quit" | "bye" =>
         System.exit(0)
 
       case "" =>
-        parseLines(khermesConfig, kafkaConfig, template, avroConfig)
+        parseLines
 
       case _ =>
-        printNotFoundCommand
-        parseLines(khermesConfig, kafkaConfig, template, avroConfig)
+        println(KhermesConsoleHelper.printNotFoundCommand)
+        parseLines
     }
+    reader.setPrompt("khermes> ")
   }
 
-  def setConfiguration(khermesConfig: Option[String] = None,
-                       kafkaConfig: Option[String] = None,
-                       template: Option[String] = None,
-                       avroConfig: Option[String] = None): Option[String] = {
+  def setConfiguration(): Option[String] = {
     println("Press Control + D to finish")
     val parsedBlock = Option(parseBlock())
     reader.setPrompt("khermes> ")
     parsedBlock
   }
 
-  def startStop(line: String,
-                firstWord: String,
-                khermesConfig: Option[String] = None,
-                kafkaConfig: Option[String] = None,
-                template: Option[String] = None,
-                avroConfig: Option[String] = None): Unit = {
-    val ids = line.replace(firstWord, "").trim.split(",").map(_.trim).filter("" != _)
-    ids.map(id => println(s"Sending $id start message"))
-    firstWord match {
-      case "start" =>
-        ids.map(id => println(s"Sending $id start message"))
-        client.start(khermesConfig, kafkaConfig, template, avroConfig, ids)
-      case "stop" =>
-        ids.map(id => println(s"Sending $id stop message"))
-        client.stop(ids)
-    }
-    reader.setPrompt("khermes> ")
+  def start(args: Map[String, List[String]], commandWord: String): Unit = {
+    Try {
+
+      val khermes = args(args.filterKeys(x => x == "h" || x == "khermes").head._1).head
+      val kafka = args(args.filterKeys(x => x == "k" || x == "kafka").head._1).head
+      val template = args(args.filterKeys(x => x == "t" || x == "template").head._1).head
+      val avro = Try(args(args.filterKeys(x => x == "a" || x == "avro").head._1).head)
+      val ids = Try(args(args.filterKeys(x => x == "i" || x == "ids").head._1))
+
+      val khermesConfig = KhermesConfig(
+        KhermesConsoleHelper.load(s"$KhermesConfigNodePath/$khermes").get,
+        KhermesConsoleHelper.load(s"$KafkaConfigNodePath/$kafka").get,
+        KhermesConsoleHelper.load(s"$TemplateNodePath/$template").get,
+        KhermesConsoleHelper.load(s"$AvroConfigNodePath/$avro")
+      )
+      client.start(khermesConfig, ids.get)
+    }.getOrElse(println("Bad arguments."))
+  }
+
+  def stop(args: Map[String, List[String]], commandWord: String): Unit = {
+    val ids = Try(args(args.filterKeys(x => x == "i" || x == "ids").head._1))
+    ids.get.map(id => println(s"Sending $id stop message"))
+    client.stop(ids.get)
   }
 
   def ls: Unit = {
@@ -131,54 +109,10 @@ case class KhermesConsoleHelper(client: KhermesClientActor) {
     println("------------------------------------   ------")
     client.ls
     Thread.sleep(KhermesConsoleHelper.TimeoutWhenLsMessage)
-    reader.setPrompt("khermes> ")
-  }
-
-  def showConfig(khermesConfig: Option[String] = None,
-                 kafkaConfig: Option[String] = None,
-                 template: Option[String] = None,
-                 avroConfig: Option[String] = None) = {
-    println("Kafka configuration:")
-    println(kafkaConfig.getOrElse("Kafka config is empty"))
-    println("Khermes configuration:")
-    println(khermesConfig.getOrElse("Khermes config is empty"))
-    println("Template:")
-    println(template.getOrElse("Template is empty"))
-    println("Avro configuration:")
-    println(avroConfig.getOrElse("Avro is empty"))
-  }
-
-  def help: Unit = {
-    println("Khermes client provide the next commands to manage your Khermes cluster:")
-    println("set khermes             Add your Khermes configuration.")
-    println("set kafka              Add your Kafka configuration.")
-    println("set template           Add your template.")
-    println("set avro               Add your Avro configuration.")
-    println("show config            Show all configurations.")
-    println("ls                     List the nodes with their current status")
-    println("start <Node Id>        Starts event generation in N nodes.")
-    println("stop <Node Id>         Stop event generation in N nodes.")
-    println("clear                  Clean the screen.")
-    println("help                   Show this help.")
-    println("exit | quit | bye      Exit of Khermes Cli.")
-    reader.setPrompt("khermes> ")
   }
 
   def clearScreen: Unit = {
     reader.clearScreen()
-  }
-
-  def printNotFoundCommand: Unit = {
-    println("Command not found. Type help to list available commands.")
-  }
-
-  def firstLoad(path: String): Option[String] = {
-    Try(khermesConfigDAO.loadConfig(path)) match {
-      case Success(config) => print(s"${path.capitalize} configuration loaded successfully.")
-        Option(config)
-      case Failure(_) => println(s"${path.capitalize} config is empty")
-        None
-    }
   }
 
   //scalastyle:on
@@ -200,4 +134,69 @@ case class KhermesConsoleHelper(client: KhermesClientActor) {
 object KhermesConsoleHelper {
 
   val TimeoutWhenLsMessage = 200L
+
+  def printNotFoundCommand: String = {
+    "Command not found. Type help to list available commands."
+  }
+
+  def help: String = {
+    s"""Khermes client provide the next commands to manage your Khermes cluster:
+       |  Usage: COMMAND [args...]
+       |
+               |  Commands:
+       |     start [command options] : Starts event generation in N nodes.
+       |       -h, --khermes    : Khermes configuration
+       |       -k, --kafka      : Kafka configuration
+       |       -t, --template   : Template to generate data
+       |       -a, --avro       : Avro configuration
+       |       -i, --ids        : Node id where start khermes
+       |     stop [command options] : Stop event generation in N nodes.
+       |       -i, --ids        : Node id where start khermes
+       |     ls                    : List the nodes with their current status
+       |     save [command options] : Save your configuration in zookeeper
+       |       -h, --khermes    : Khermes configuration
+       |       -k, --kafka      : Kafka configuration
+       |       -t, --template   : Template to generate data
+       |       -a, --avro       : Avro configuration
+       |     show [command options] : Show your configuration
+       |       -h, --khermes    : Khermes configuration
+       |       -k, --kafka      : Kafka configuration
+       |       -t, --template   : Template to generate data
+       |       -a, --avro       : Avro configuration
+       |     clear                 : Clean the screen.
+       |     help                  : Print this usage.
+       |     exit | quit | bye     : Exit of Khermes Cli.   """.stripMargin
+  }
+
+  def show(args: Map[String, List[String]], firstWord: String): String = {
+    Try {
+      val a = args.map {
+        case ("h", _) | ("khermes", _) => load(s"$KhermesConfigNodePath/${args.head._2.head}").getOrElse(s"Khermes ${args.head._2.head} config is empty")
+        case ("k", _) | ("kafka", _) => load(s"$KafkaConfigNodePath/${args.head._2.head}").getOrElse(s"Khermes ${args.head._2.head} config is empty")
+        case ("t", _) | ("template", _) => load(s"$TemplateNodePath/${args.head._2.head}").getOrElse(s"Khermes ${args.head._2.head} config is empty")
+        case ("a", _) | ("avro", _) => load(s"$AvroConfigNodePath/${args.head._2.head}").getOrElse(s"Khermes ${args.head._2.head} config is empty")
+        case value => s"Arg ${value._1} is not correct."
+      }
+      a.mkString
+    }.getOrElse("Bad arguments.")
+  }
+
+  def save(args: Map[String, List[String]], commandWord: String, config: Option[String]): Unit = {
+    Try {
+      args.foreach {
+        case ("h", _) | ("khermes", _) => khermesConfigDAO.saveConfig(s"$KhermesConfigNodePath/${args.head._2.head}", config.get)
+        case ("k", _) | ("kafka", _) => khermesConfigDAO.saveConfig(s"$KafkaConfigNodePath/${args.head._2.head}", config.get)
+        case ("t", _) | ("template", _) => khermesConfigDAO.saveConfig(s"$TemplateNodePath/${args.head._2.head}", config.get)
+        case ("a", _) | ("avro", _) => khermesConfigDAO.saveConfig(s"$AvroConfigNodePath/${args.head._2.head}", config.get)
+        case value => println(s"Arg ${value._1} is not correct.")
+      }
+    }.getOrElse(println("Bad arguments."))
+  }
+
+  def load(path: String): Option[String] = {
+    Try(khermesConfigDAO.loadConfig(path)) match {
+      case Success(config) => Option(config)
+      case Failure(_) => None
+    }
+  }
 }

--- a/src/test/scala/com/stratio/khermes/helpers/ArgsParserTest.scala
+++ b/src/test/scala/com/stratio/khermes/helpers/ArgsParserTest.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.khermes.helpers
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+@RunWith(classOf[JUnitRunner])
+class ArgsParserTest extends FlatSpec with Matchers{
+    it should "give a message with configuration empties" in {
+      val line = "start --kafka k1 -t t1 --khermes k1 --ids 11231232123213 3123123434535345345"
+      val argsParser = new ArgsParser
+      argsParser.parse(line) shouldBe Map("kafka" -> List("k1"),"t"->List("t1"),"khermes"->List("k1"),"ids"->List("11231232123213","3123123434535345345"))
+    }
+}

--- a/src/test/scala/com/stratio/khermes/helpers/ArgsParserTest.scala
+++ b/src/test/scala/com/stratio/khermes/helpers/ArgsParserTest.scala
@@ -20,10 +20,25 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers}
 
 @RunWith(classOf[JUnitRunner])
-class ArgsParserTest extends FlatSpec with Matchers{
-    it should "give a message with configuration empties" in {
-      val line = "start --kafka k1 -t t1 --khermes k1 --ids 11231232123213 3123123434535345345"
-      val argsParser = new ArgsParser
-      argsParser.parse(line) shouldBe Map("kafka" -> List("k1"),"t"->List("t1"),"khermes"->List("k1"),"ids"->List("11231232123213","3123123434535345345"))
-    }
+class ArgsParserTest extends FlatSpec with Matchers {
+  it should "give a map with arg as key and a list of the values" in {
+    val line = "start --kafka k1 -t t1 --khermes k1 --ids 11231232123213 3123123434535345345"
+    val argsParser = new ArgsParser
+    argsParser.commandWord(line) shouldBe "start"
+    argsParser.parseArgsValues(line) shouldBe Map("kafka" -> List("k1"), "t" -> List("t1"), "khermes" -> List("k1"), "ids" -> List("11231232123213", "3123123434535345345"))
+  }
+
+  it should "when an arg do not have value that return a empty list" in {
+    val line = "start --kafka -t t1 --khermes k1 --ids 11231232123213 3123123434535345345"
+    val argsParser = new ArgsParser
+    argsParser.parseArgsValues(line) shouldBe Map("kafka" -> List(), "t" -> List("t1"), "khermes" -> List("k1"), "ids" -> List("11231232123213", "3123123434535345345"))
+  }
+
+  it should "give an empty map when there are not args" in {
+    val line = "save"
+    val argsParser = new ArgsParser
+    argsParser.parseArgsValues(line) shouldBe Map()
+  }
+
+
 }

--- a/src/test/scala/com/stratio/khermes/helpers/KhermesConsoleHelperTest.scala
+++ b/src/test/scala/com/stratio/khermes/helpers/KhermesConsoleHelperTest.scala
@@ -23,13 +23,13 @@ import org.scalatest.{FlatSpec, Matchers}
 class KhermesConsoleHelperTest extends FlatSpec
   with Matchers {
   val helpMessage =
-    s"""Khermes client provide the next commands to manage your Khermes cluster:
+    s"""Khermes client provides the next commands to manage your Khermes cluster:
        |  Usage: COMMAND [args...]
        |
                |  Commands:
        |     start [command options] : Starts event generation in N nodes.
-       |       -h, --khermes    : Khermes configuration
-       |       -k, --kafka      : Kafka configuration
+       |       -kh, --khermes    : Khermes configuration
+       |       -ka, --kafka      : Kafka configuration
        |       -t, --template   : Template to generate data
        |       -a, --avro       : Avro configuration
        |       -i, --ids        : Node id where start khermes
@@ -37,13 +37,13 @@ class KhermesConsoleHelperTest extends FlatSpec
        |       -i, --ids        : Node id where start khermes
        |     ls                    : List the nodes with their current status
        |     save [command options] : Save your configuration in zookeeper
-       |       -h, --khermes    : Khermes configuration
-       |       -k, --kafka      : Kafka configuration
+       |       -kh, --khermes    : Khermes configuration
+       |       -ka, --kafka      : Kafka configuration
        |       -t, --template   : Template to generate data
        |       -a, --avro       : Avro configuration
        |     show [command options] : Show your configuration
-       |       -h, --khermes    : Khermes configuration
-       |       -k, --kafka      : Kafka configuration
+       |       -kh, --khermes    : Khermes configuration
+       |       -ka, --kafka      : Kafka configuration
        |       -t, --template   : Template to generate data
        |       -a, --avro       : Avro configuration
        |     clear                 : Clean the screen.
@@ -55,9 +55,9 @@ class KhermesConsoleHelperTest extends FlatSpec
   it should "give a message a help message" in {
     khermesConsoleHelper.help shouldBe helpMessage
   }
-//  it should "give a message a when the command is not valid" in {
-//    khermesConsoleHelper.printNotFoundCommand shouldBe "Command not found. Type help to list available commands."
-//  }
+  it should "give a message a when the command is not valid" in {
+    khermesConsoleHelper.printNotFoundCommand shouldBe "Command not found. Type help to list available commands."
+  }
 //  it should "give a config message when show a config that you save" in {
 //    khermesConsoleHelper.save(Map("kafka" -> List("k1")),"save",Option("k1Config"))
 //    khermesConsoleHelper.save(Map("khermes" -> List("h1")),"save",Option("h1Config"))

--- a/src/test/scala/com/stratio/khermes/helpers/KhermesConsoleHelperTest.scala
+++ b/src/test/scala/com/stratio/khermes/helpers/KhermesConsoleHelperTest.scala
@@ -55,24 +55,23 @@ class KhermesConsoleHelperTest extends FlatSpec
   it should "give a message a help message" in {
     khermesConsoleHelper.help shouldBe helpMessage
   }
-  it should "give a message a when the command is not valid" in {
-    khermesConsoleHelper.printNotFoundCommand shouldBe "Command not found. Type help to list available commands."
-  }
-  it should "give a config message when show a config that you save" in {
-    khermesConsoleHelper.save(Map("kafka" -> List("k1")),"save",Option("k1Config"))
-    khermesConsoleHelper.save(Map("khermes" -> List("h1")),"save",Option("h1Config"))
-    khermesConsoleHelper.save(Map("template" -> List("t1")),"save",Option("t1Config"))
-    khermesConsoleHelper.save(Map("avro" -> List("a1")),"save",Option("a1Config"))
-    khermesConsoleHelper.show(Map("kafka" -> List("k1")),"show") shouldBe "k1Config"
-    khermesConsoleHelper.show(Map("khermes" -> List("h1")),"show") shouldBe "h1Config"
-    khermesConsoleHelper.show(Map("template" -> List("t1")),"show") shouldBe "t1Config"
-    khermesConsoleHelper.show(Map("avro" -> List("a1")),"show") shouldBe "a1Config"
-  }
-  it should "load a None when do not find a config in a specific path" in {
-    khermesConsoleHelper.load("")shouldBe None
-  }
-  it should "give a message a when the params are not correct" in {
-    khermesConsoleHelper.show(Map("fail" -> List("a1")),"show") shouldBe "Arg fail is not correct."
-//    khermesConsoleHelper.save(Map("fail" -> List("a1")),"save",None) shouldBe "Arg fail is not correct."
-  }
+//  it should "give a message a when the command is not valid" in {
+//    khermesConsoleHelper.printNotFoundCommand shouldBe "Command not found. Type help to list available commands."
+//  }
+//  it should "give a config message when show a config that you save" in {
+//    khermesConsoleHelper.save(Map("kafka" -> List("k1")),"save",Option("k1Config"))
+//    khermesConsoleHelper.save(Map("khermes" -> List("h1")),"save",Option("h1Config"))
+//    khermesConsoleHelper.save(Map("template" -> List("t1")),"save",Option("t1Config"))
+//    khermesConsoleHelper.save(Map("avro" -> List("a1")),"save",Option("a1Config"))
+//    khermesConsoleHelper.show(Map("kafka" -> List("k1")),"show") shouldBe "k1Config"
+//    khermesConsoleHelper.show(Map("khermes" -> List("h1")),"show") shouldBe "h1Config"
+//    khermesConsoleHelper.show(Map("template" -> List("t1")),"show") shouldBe "t1Config"
+//    khermesConsoleHelper.show(Map("avro" -> List("a1")),"show") shouldBe "a1Config"
+//  }
+//  it should "load a None when do not find a config in a specific path" in {
+//    khermesConsoleHelper.load("")shouldBe None
+//  }
+//  it should "give a message a when the params are not correct" in {
+//    khermesConsoleHelper.show(Map("fail" -> List("a1")),"show") shouldBe "Arg fail is not correct."
+//  }
 }

--- a/src/test/scala/com/stratio/khermes/helpers/KhermesConsoleHelperTest.scala
+++ b/src/test/scala/com/stratio/khermes/helpers/KhermesConsoleHelperTest.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.khermes.helpers
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+@RunWith(classOf[JUnitRunner])
+class KhermesConsoleHelperTest extends FlatSpec
+  with Matchers {
+  val helpMessage =
+    s"""Khermes client provide the next commands to manage your Khermes cluster:
+       |  Usage: COMMAND [args...]
+       |
+               |  Commands:
+       |     start [command options] : Starts event generation in N nodes.
+       |       -h, --khermes    : Khermes configuration
+       |       -k, --kafka      : Kafka configuration
+       |       -t, --template   : Template to generate data
+       |       -a, --avro       : Avro configuration
+       |       -i, --ids        : Node id where start khermes
+       |     stop [command options] : Stop event generation in N nodes.
+       |       -i, --ids        : Node id where start khermes
+       |     ls                    : List the nodes with their current status
+       |     save [command options] : Save your configuration in zookeeper
+       |       -h, --khermes    : Khermes configuration
+       |       -k, --kafka      : Kafka configuration
+       |       -t, --template   : Template to generate data
+       |       -a, --avro       : Avro configuration
+       |     show [command options] : Show your configuration
+       |       -h, --khermes    : Khermes configuration
+       |       -k, --kafka      : Kafka configuration
+       |       -t, --template   : Template to generate data
+       |       -a, --avro       : Avro configuration
+       |     clear                 : Clean the screen.
+       |     help                  : Print this usage.
+       |     exit | quit | bye     : Exit of Khermes Cli.   """.stripMargin
+
+  val khermesConsoleHelper = KhermesConsoleHelper
+
+  it should "give a message a help message" in {
+    khermesConsoleHelper.help shouldBe helpMessage
+  }
+  it should "give a message a when the command is not valid" in {
+    khermesConsoleHelper.printNotFoundCommand shouldBe "Command not found. Type help to list available commands."
+  }
+  it should "give a config message when show a config that you save" in {
+    khermesConsoleHelper.save(Map("kafka" -> List("k1")),"save",Option("k1Config"))
+    khermesConsoleHelper.save(Map("khermes" -> List("h1")),"save",Option("h1Config"))
+    khermesConsoleHelper.save(Map("template" -> List("t1")),"save",Option("t1Config"))
+    khermesConsoleHelper.save(Map("avro" -> List("a1")),"save",Option("a1Config"))
+    khermesConsoleHelper.show(Map("kafka" -> List("k1")),"show") shouldBe "k1Config"
+    khermesConsoleHelper.show(Map("khermes" -> List("h1")),"show") shouldBe "h1Config"
+    khermesConsoleHelper.show(Map("template" -> List("t1")),"show") shouldBe "t1Config"
+    khermesConsoleHelper.show(Map("avro" -> List("a1")),"show") shouldBe "a1Config"
+  }
+  it should "load a None when do not find a config in a specific path" in {
+    khermesConsoleHelper.load("")shouldBe None
+  }
+  it should "give a message a when the params are not correct" in {
+    khermesConsoleHelper.show(Map("fail" -> List("a1")),"show") shouldBe "Arg fail is not correct."
+//    khermesConsoleHelper.save(Map("fail" -> List("a1")),"save",None) shouldBe "Arg fail is not correct."
+  }
+}


### PR DESCRIPTION
## Description
- Now you can save different configurations in zookeeper.
- You can show your configurations.
Example:
show --kafka k1
start -t t1 -k k1 -h h1 --ids 92138793

### Testing
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Coverage (>90%)

### Documentation
- [ ] Changelog update
- [x] Documentation entry

### Scalastyle
Result of scalastyle execution: 
