### PR TITLE
Feature/ws integration 2

### DIFF
--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -43,6 +43,8 @@
 </div>
 
 <div class="container" id="content">
+    <textarea id="command" rows="12" style="min-width: 60%"></textarea><br/>
+    <button type="button" onclick="send();">Send command</button>
 </div>
 
 <script src="http://getbootstrap.com/2.3.2/assets/js/jquery.js"></script>

--- a/src/main/resources/web/js/app.js
+++ b/src/main/resources/web/js/app.js
@@ -1,49 +1,52 @@
-window.onload = function() {
-  setupWebSocket(wsURL("input"));
-  setupWebSocket(wsURL("output"));
+setupWebSocket(wsURL("input"), "input");
+setupWebSocket(wsURL("output"), "output");
 
-  function setupWebSocket(endpoint) {
-    if(window.ws) {
-      window.ws.close();
-    }
-
-    var ws = new WebSocket(endpoint)
-
-    ws.onopen = function(event) {
-      console.info("Connected to the server")
-    };
-
-    ws.onmessage = function(event) {
-      console.log(event);
-      createEventDiv(event);
-    };
-
-    ws.onclose = function() {
-      console.info("Disconnected to the server");
-      setupWebSocket(this.url)
-    };
-
-    window.ws = ws;
+function setupWebSocket(endpoint, name) {
+  if(window[name]) {
+    window[name].close();
   }
 
-  function wsURL(path) {
-    var protocol = (location.protocol === 'https:') ? 'wss://' : 'ws://';
-    var url = protocol + location.host;
-    if(location.hostname === 'localhost') {
-      url += '/' + location.pathname.split('/')[1];
-    } else {
-      url += '/';
-    }
-    return url + path;
+  var ws = new WebSocket(endpoint)
+
+  ws.onopen = function(event) {
+    console.info("Connected to the server")
   };
 
-
-  function createEventDiv(obj) {
-      var newDiv = "";
-      newDiv += '<div class="alert alert-info" role="alert">';
-      newDiv += '<p>' + obj.data + '</p>';
-      newDiv += "</div>";
-      $("div#content").prepend(newDiv);
+  ws.onmessage = function(event) {
+    console.log(event);
+    createEventDiv(event);
   };
 
+  ws.onclose = function() {
+    console.info("Disconnected to the server");
+    setupWebSocket(this.url)
+  };
+
+  window[name] = ws;
+}
+
+function wsURL(path) {
+  var protocol = (location.protocol === 'https:') ? 'wss://' : 'ws://';
+  var url = protocol + location.host;
+  if(location.hostname === 'localhost') {
+    url += '/' + location.pathname.split('/')[1];
+  } else {
+    url += '/';
+  }
+  return url + path;
+};
+
+function createEventDiv(obj) {
+  var newDiv = "";
+  newDiv += '<div class="feedback alert alert-info" role="alert" style="margin-top: 20px">';
+  newDiv += '<p>' + obj.data + '</p>';
+  newDiv += "</div>";
+  $(".feedback" ).remove();
+  $("div#content").append(newDiv);
+};
+
+function send() {
+  var messageToSend = document.getElementById('command').value;
+  document.getElementById('command').value = '';
+  window["input"].send(messageToSend);
 };

--- a/src/main/scala/com/stratio/khermes/clients/http/protocols/WSProtocolMessage.scala
+++ b/src/main/scala/com/stratio/khermes/clients/http/protocols/WSProtocolMessage.scala
@@ -18,41 +18,61 @@ package com.stratio.khermes.clients.http.protocols
 
 import com.stratio.khermes.clients.http.protocols.WsProtocolCommand.WsProtocolCommandValue
 
-case class WSProtocolMessage(command: WsProtocolCommandValue, args: Seq[String])
+case class WSProtocolMessage(command: WsProtocolCommandValue, args: Map[String, String])
 
 case object WsProtocolCommand extends Enumeration {
 
   type WsProtocolCommandValue = Value
+
   val Ls = Value("ls")
   val Start = Value("start")
-  val CreateTemplate = Value("create template")
-  val ReadTemplate = Value("read template")
-  val UpdateTemplate = Value("update template")
-  val DeleteTemplate = Value("delete template")
+  val Stop = Value("stop")
+  val CreateTwirlTemplate = Value("create twirl-template")
+  val CreateKafkaConfig = Value("create kafka-config")
+  val CreateGeneratorConfig = Value("create generator-config")
+  val CreateAvroConfig = Value("create avro-config")
+
+  val ArgsName = "name"
+  val ArgsContent = "content"
+  val ArgsTwirlTemplate = "twirl-template"
+  val ArgsKafkaConfig = "kafka-config"
+  val ArgsGeneratorConfig = "generator-config"
+  val ArgsAvroConfig = "avro-config"
+  val ArgsNodeIds = "node-ids"
 
   //scalastyle:off
   def parseTextBlock(block: String): WSProtocolMessage = {
     def parseLines(lines: Seq[String],
-                   command: Option[String],
-                   args: Seq[String],
+                   commandOption: Option[String],
+                   argOption: Option[String],
+                   args: Map[String, String],
                    isCommand: Boolean,
-                   isArg: Boolean) : (Option[String], Seq[String]) = {
+                   isArg: Boolean) : (Option[String], Map[String, String]) = {
       lines.headOption match {
-        case None => (command, args)
-        case Some(line) if line.trim == "" => parseLines(lines.tail, command, args, isCommand, isArg)
-        case Some(line) if line.toLowerCase == "[command]" => parseLines(lines.tail, command, args, true, false)
-        case Some(line) if line.toLowerCase() == "[arg]" => parseLines(lines.tail, command, args, false, true)
-        case Some(line) if isCommand => parseLines(lines.tail, Option(line), args, true, false)
-        case Some(line) if isArg => parseLines(lines.tail, Option(line), args ++ Seq(line), false, true)
-        case _ => parseLines(lines.tail, command, args, isCommand, isArg)
+        case None => (commandOption, args)
+        case Some(line) if line.trim == "" =>
+          parseLines(lines.tail, commandOption, argOption, args, isCommand, isArg)
+        case Some(line) if line.toLowerCase == "[command]" =>
+          parseLines(lines.tail, commandOption, argOption, args, true, false)
+        case Some(line) if line.toLowerCase().startsWith("[") =>
+          parseLines(lines.tail, commandOption, Option(line.replace("[", "").replace("]", "")), args, false, true)
+        case Some(line) if isCommand =>
+          parseLines(lines.tail, Option(line), argOption, args, true, false)
+        case Some(line) if isArg =>
+          val arg = argOption.getOrElse(
+            throw new IllegalStateException("Something was wrong taking the name of the arg (it is None)"))
+          val value = (args.get(arg).toSeq ++ Seq(line)).mkString("\n")
+          val newArgs = args + (arg -> value)
+          parseLines(lines.tail, commandOption, argOption, newArgs, false, true)
+        case _ =>
+          parseLines(lines.tail, commandOption, argOption, args, isCommand, isArg)
       }
     }
 
-    val result = parseLines(block.split("\n"), None, Seq.empty, false, false)
+    val result = parseLines(block.split("\n"), None, None, Map.empty, false, false)
     WSProtocolMessage(
       WsProtocolCommand.withName(result._1.getOrElse(
-        throw new IllegalStateException("Imposible to parse command"))), result._2)
-
+        throw new IllegalStateException("Impossible to parse command"))), result._2)
   }
   //scalastyle:on
 }

--- a/src/main/scala/com/stratio/khermes/clients/shell/KhermesConsoleHelper.scala
+++ b/src/main/scala/com/stratio/khermes/clients/shell/KhermesConsoleHelper.scala
@@ -29,10 +29,10 @@ case class KhermesConsoleHelper(client: KhermesClientActor) {
   lazy val reader = createDefaultReader()
 
   parseLines(
-    firstLoad(AppConstants.KhermesConfigNodePath),
-    firstLoad(AppConstants.KafkaConfigNodePath),
-    firstLoad(AppConstants.TemplateNodePath),
-    firstLoad(AppConstants.AvroConfigNodePath)
+    firstLoad(AppConstants.GeneratorConfigPath),
+    firstLoad(AppConstants.KafkaConfigPath),
+    firstLoad(AppConstants.TwirlTemplatePath),
+    firstLoad(AppConstants.AvroConfigPath)
   )
 
   //scalastyle:off
@@ -43,22 +43,22 @@ case class KhermesConsoleHelper(client: KhermesClientActor) {
     reader.readLine.trim match {
       case "set khermes" =>
         val config = setConfiguration(khermesConfig, kafkaConfig, template, avroConfig)
-        configDAO.create(AppConstants.KhermesConfigNodePath, config.get)
+        configDAO.create(AppConstants.GeneratorConfigPath, config.get)
         parseLines(config, kafkaConfig, template, avroConfig)
 
       case "set kafka" =>
         val config = setConfiguration(khermesConfig, kafkaConfig, template, avroConfig)
-        configDAO.create(AppConstants.KafkaConfigNodePath, config.get)
+        configDAO.create(AppConstants.KafkaConfigPath, config.get)
         parseLines(khermesConfig, config, template, avroConfig)
 
       case "set template" =>
         val config = setConfiguration(khermesConfig, kafkaConfig, template, avroConfig)
-        configDAO.create(AppConstants.TemplateNodePath, config.get)
+        configDAO.create(AppConstants.TwirlTemplatePath, config.get)
         parseLines(khermesConfig, kafkaConfig, config, avroConfig)
 
       case "set avro" =>
         val config = setConfiguration(khermesConfig, kafkaConfig, template, avroConfig)
-        configDAO.create(AppConstants.AvroConfigNodePath, config.get)
+        configDAO.create(AppConstants.AvroConfigPath, config.get)
         parseLines(khermesConfig, kafkaConfig, template, config)
 
       case value if value.startsWith("start") =>

--- a/src/main/scala/com/stratio/khermes/commons/constants/AppConstants.scala
+++ b/src/main/scala/com/stratio/khermes/commons/constants/AppConstants.scala
@@ -39,10 +39,10 @@ object AppConstants {
   val ZookeeperRetryAttempts = "zookeeper.retryAttempts"
   val ZookeeperRetryInterval = "zookeeper.retryInterval"
 
-  val KafkaConfigNodePath = "kafka"
-  val KhermesConfigNodePath = "khermes"
-  val TemplateNodePath = "template"
-  val AvroConfigNodePath = "avro"
+  val KafkaConfigPath = "kafka-config"
+  val GeneratorConfigPath = "generator-config"
+  val TwirlTemplatePath = "twirl-template"
+  val AvroConfigPath = "avro-config"
 
   val DefaultWSHost = "localhost"
   val DefaultWSPort = 8080

--- a/src/test/scala/com/stratio/khermes/clients/http/protocols/WSProtocolMessageTest.scala
+++ b/src/test/scala/com/stratio/khermes/clients/http/protocols/WSProtocolMessageTest.scala
@@ -20,23 +20,25 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers}
 
-//@RunWith(classOf[JUnitRunner])
+@RunWith(classOf[JUnitRunner])
 class WSProtocolMessageTest extends FlatSpec with Matchers  {
 
   "A WSProtocolCommand" should "parse a configuration" in {
-
     val block =
       """
         |[command]
         |ls
-        |[arg]
-        |arg1 - text
-        |arg1 - text
-        |[arg]
-        |arg2 - text
-        |arg2 - text
+        |[arg1]
+        |one line content
+        |[arg2]
+        |multiline line 1 content
+        |multiline line 2 content
       """.stripMargin
 
-    WsProtocolCommand.parseTextBlock(block)
+    val result = WsProtocolCommand.parseTextBlock(block)
+    result should be(WSProtocolMessage(WsProtocolCommand.Ls, Map(
+      "arg1" -> "one line content",
+      "arg2" -> "multiline line 1 content\nmultiline line 2 content"
+    )))
   }
 }


### PR DESCRIPTION
## Description
The Protocol used to manage Khermes is full implemented. You can open http://localhost:8080 and write your commands in the textarea to test.

This is an example of commands that you can write:

```
[command]
create twirl-template
[name]
template1
[content]
@import com.stratio.khermes.helpers.faker.Faker

@(faker: Faker)
{
  "name" : "@(faker.Name.firstName)"
}
############################################################
[command]
create kafka-config
[name]
kafka1
[content]
kafka {
  bootstrap.servers = "localhost:9092"
  acks = "-1"
  key.serializer = "org.apache.kafka.common.serialization.StringSerializer"
  value.serializer = "org.apache.kafka.common.serialization.StringSerializer"
}
############################################################
[command]
create generator-config
[name]
generator1
[content]
khermes {
  templates-path = "/tmp/hermes/templates"
  topic = "alicia"
  template-name = "chustasTemplate"
  i18n = "ES"

  timeout-rules {
    number-of-events: 10
    duration: 2 seconds
  }

  #stop-rules {
  #  number-of-events: 5000
  #}
}
############################################################
[command]
start
[twirl-template]
template1
[kafka-config]
kafka1
[generator-config]
generator1
############################################################
[command]
ls
############################################################
[command]
stop
[node-ids]
51a50bf6-a919-4c04-830a-b3fc7e1112bf
```

### Testing
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Coverage (>90%)

### Documentation
- [ ] Changelog update
- [ ] Documentation entry

### Scalastyle
Result of scalastyle execution: 
