### PR TITLE
[86] Create kafka-config command added to the console

### DIFF
--- a/src/main/resources/web/console.html
+++ b/src/main/resources/web/console.html
@@ -11,15 +11,27 @@
     <link href="../css/jquery.terminal.css" rel="stylesheet"/>
 </head>
 <body>
-
 <script>
     jQuery(document).ready(function($) {
-        var id = 1;
         $('body').terminal(function(command, term) {
             if (command == 'help') {
-                term.echo("available commands are ls");
+                term.echo("available commands are ls, create kafka-config");
             } else if (command == 'ls'){
                 sendMessage('[command]\nls');
+            } else if (command == 'create kafka-config') {
+                var name = '';
+                var config = '';
+                term.push(function(kafkaConfigName, term) {
+                    name = kafkaConfigName;
+                    term.push(function(kafkaConfig, term) {
+                        config = kafkaConfig;
+                        sendMessage('[command]\ncreate kafka-config\n[name]\n'+name+'\n[content]\n'+config+'\n');
+                    }, {
+                        prompt: 'khermes> kafka-config> Please introduce the kafka-config> ',
+                        name: 'kafka-config'});
+                }, {
+                    prompt: 'khermes> kafka-config> Please introduce the kafka-config name> ',
+                    name: 'kafka-config-name'});
             } else {
                 term.echo("unknown command " + command);
             }

--- a/src/main/resources/web/js/console.js
+++ b/src/main/resources/web/js/console.js
@@ -13,10 +13,10 @@ function setupWebSocket(endpoint, name, term) {
   ws.onmessage = function(event) {
     console.log(event);
     data = event.data;
-    if (data.indexOf("value") != -1)
+    if (data.indexOf("-") != -1)
        term.echo(parseLs(event.data))
     else
-       term.echo(event.data);
+       term.echo(parseOkResponse(event.data));
   };
 
   ws.onclose = function() {
@@ -38,6 +38,11 @@ function parseLs(data) {
     separator = "-------------------------------------------------";
     var response = JSON.parse(data);
     return header + "\n" + separator + "\n"+ response.value;
+}
+
+function parseOkResponse(data) {
+    var response = JSON.parse(data);
+    return "Command result: "+ response.value;
 }
 
 function sendMessage(msg){


### PR DESCRIPTION
## Description

This PR includes the changes to allow the user introduce the kafka config through the brand new web console. When the user types the "create kafka-config" command the prompt will change as below:
```
khermes> kafka-config> Please introduce the kafka-config name>
```
After introducing the kafka-config name template, the prompt will change again as below:
```
khermes> kafka-config> Please introduce the kafka-config>
```
After introducing the kafka config the user should type exit to come back to the previous options. (WIP -> we might take the user to the previous options automatically!)

Note: The console.html file is getting too big, we should refactor it and move the functionality to a javascript file!!