### PR TITLE
added create twirl-template command to console

### DIFF
--- a/src/main/resources/web/console.html
+++ b/src/main/resources/web/console.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8"/>
     <title>Khermes Terminal</title>
     <meta name="Description" content="Khermes terminal implementation using the jquery.terminal project"/>
     <script src="../js/jquery-1.7.1.min.js"></script>
@@ -15,7 +15,7 @@
     jQuery(document).ready(function($) {
         $('body').terminal(function(command, term) {
             if (command == 'help') {
-                term.echo("available commands are ls, create kafka-config");
+                term.echo("available commands are ls, create kafka-config, create twirl-template");
             } else if (command == 'ls'){
                 sendMessage('[command]\nls');
             } else if (command == 'create kafka-config') {
@@ -32,6 +32,20 @@
                 }, {
                     prompt: 'khermes> kafka-config> Please introduce the kafka-config name> ',
                     name: 'kafka-config-name'});
+            } else if (command == 'create twirl-template') {
+                var name = '';
+                var config = '';
+                term.push(function(twirlTemplate, term) {
+                    name = twirlTemplate;
+                    term.push(function(twirlConfig, term) {
+                        config = twirlConfig;
+                        sendMessage('[command]\ncreate twirl-template\n[name]\n'+name+'\n[content]\n'+config+'\n');
+                    }, {
+                        prompt: 'khermes> twirl-template> Please introduce the twirl-template> \n',
+                        name: 'twirl-template'});
+                }, {
+                    prompt: 'khermes> twirl-template> Please introduce the twirl-template name> ',
+                    name: 'twirl-template-name'});
             } else {
                 term.echo("unknown command " + command);
             }
@@ -51,5 +65,7 @@
             }
         });
     });
+
+
 </script>
 </body>


### PR DESCRIPTION
## Description

This PR includes the changes to allow the user introduce a twirl template through the brand new web console. When the user types the "create twirl-template" command the prompt will change as below:
```
khermes> twirl-template> Please introduce the twirl-template name>
```
After introducing the twirl-template name template, the prompt will change again as below:
```
khermes> twirl-template> Please introduce the twirl-template>
```
After introducing the twirl-template, the user should type exit to come back to the previous options. (WIP -> we might take the user to the previous options automatically!)

Note: The console.html file is getting too big, we should refactor it and move the functionality to a javascript file!!