### PR TITLE
[Khermes #97]Commands show configs.

### DIFF
--- a/src/main/resources/web/js/console.js
+++ b/src/main/resources/web/js/console.js
@@ -1,7 +1,7 @@
 jQuery(document).ready(function($) {
     $('body').terminal(function(command, term) {
         if (command == 'help') {
-            term.echo("available commands are ls, create kafka-config, create twirl-template, create generator-config, create avro-config, start, stop");
+            term.echo("available commands are ls, create kafka-config, create twirl-template, create generator-config, create avro-config, start, stop, show kafka-config, show generator-config, show avro-config, show twirl-template");
         } else if (command == 'ls'){
             sendMessage('[command]\nls');
         } else if (command == 'create kafka-config') {
@@ -16,6 +16,18 @@ jQuery(document).ready(function($) {
             start(term)
         }else if (command.startsWith('stop')) {
             stop(term)
+        }
+        else if (command == 'show kafka-config') {
+            sendMessage('[command]\nshow kafka-config')
+        }
+         else if (command == 'show generator-config') {
+            sendMessage('[command]\nshow generator-config')
+        }
+        else if (command == 'show avro-config') {
+            sendMessage('[command]\nshow avro-config')
+        }
+        else if (command == 'show twirl-template') {
+            sendMessage('[command]\nshow twirl-template')
         }
         else {
             term.echo("unknown command " + command);

--- a/src/main/scala/com/stratio/khermes/clients/http/protocols/WSProtocolMessage.scala
+++ b/src/main/scala/com/stratio/khermes/clients/http/protocols/WSProtocolMessage.scala
@@ -32,6 +32,11 @@ case object WsProtocolCommand extends Enumeration {
   val CreateGeneratorConfig = Value("create generator-config")
   val CreateAvroConfig = Value("create avro-config")
 
+  val ShowTwirlTemplate = Value("show twirl-template")
+  val ShowKafkaConfig = Value("show kafka-config")
+  val ShowGeneratorConfig = Value("show generator-config")
+  val ShowAvroConfig = Value("show avro-config")
+
   val ArgsName = "name"
   val ArgsContent = "content"
   val ArgsTwirlTemplate = "twirl-template"

--- a/src/main/scala/com/stratio/khermes/cluster/collector/CommandCollectorActor.scala
+++ b/src/main/scala/com/stratio/khermes/cluster/collector/CommandCollectorActor.scala
@@ -72,6 +72,18 @@ class CommandCollectorActor extends ActorPublisher[CommandCollectorActor.Result]
     case WSProtocolMessage(WsProtocolCommand.CreateAvroConfig, args) =>
       createConfig(args, WsProtocolCommand.CreateAvroConfig, AppConstants.AvroConfigPath)
 
+    case WSProtocolMessage(WsProtocolCommand.ShowTwirlTemplate, _) =>
+      showConfig(AppConstants.TwirlTemplatePath)
+
+    case WSProtocolMessage(WsProtocolCommand.ShowGeneratorConfig, _) =>
+      showConfig(AppConstants.GeneratorConfigPath)
+
+    case WSProtocolMessage(WsProtocolCommand.ShowKafkaConfig, _) =>
+      showConfig(AppConstants.KafkaConfigPath)
+
+    case WSProtocolMessage(WsProtocolCommand.ShowAvroConfig, _) =>
+      showConfig(AppConstants.AvroConfigPath)
+
     case result: NodeSupervisorActor.Result =>
       collectResult(result)
 
@@ -128,6 +140,11 @@ class CommandCollectorActor extends ActorPublisher[CommandCollectorActor.Result]
 
     configDAO.create(s"${basePath}/${name}", content)
     self ! Result("OK", s"Created node in ZK: ${basePath}/${name}")
+  }
+
+  def showConfig(basePath: String): Unit ={
+    val list = configDAO.list(s"$basePath")
+    self ! Result(s"OK \n$list", s"Show config of $basePath")
   }
 
   def checkCommandHasEnd(): Unit = {

--- a/src/main/scala/com/stratio/khermes/persistence/dao/BaseDAO.scala
+++ b/src/main/scala/com/stratio/khermes/persistence/dao/BaseDAO.scala
@@ -27,4 +27,6 @@ trait BaseDAO[T] {
   def delete(entity: T)
 
   def exists(entity: T): Boolean
+
+  def list(entity: T): T
 }

--- a/src/main/scala/com/stratio/khermes/persistence/dao/ZkDAO.scala
+++ b/src/main/scala/com/stratio/khermes/persistence/dao/ZkDAO.scala
@@ -68,6 +68,12 @@ class ZkDAO(connectionServer: Option[String] = None) extends BaseDAO[String] wit
     curatorFramework.setData().forPath(s"${AppConstants.ZookeeperParentPath}/$path", config.getBytes())
   }
 
+  override def list(path: String): String = {
+    val children = curatorFramework.getChildren.forPath(s"${AppConstants.ZookeeperParentPath}/$path")
+    import collection.JavaConverters._
+    children.asScala.mkString("\n")
+  }
+
 
   def buildCurator(connectionServer: String): CuratorFramework = {
     Try {

--- a/src/test/scala/com/stratio/khermes/persistence/dao/ZkDAOTest.scala
+++ b/src/test/scala/com/stratio/khermes/persistence/dao/ZkDAOTest.scala
@@ -41,6 +41,12 @@ class ZkDAOTest extends FlatSpec
       khermesConfigDAO.delete("stratio")
       data shouldBe "myConfig2"
     }
+    "An KhermesConfig" should "have a way to obtain the list of configs" in {
+      khermesConfigDAO.create("a/b/c","config1")
+      khermesConfigDAO.create("a/b/d","config2")
+      khermesConfigDAO.list("a/b") shouldBe "c\nd"
+    }
+
     it should "raise an exception when it save or load a config in a path that does not exists" in {
       an[KhermesException] should be thrownBy khermesConfigDAO.read("")
       an[KhermesException] should be thrownBy khermesConfigDAO.create("", "config")


### PR DESCRIPTION
## Description
-You can use show kafka-config, show generator-config, show avro-config, show twirl-template commands
- If you launch a show kafka-config command you must recive a list with your kafka-config stored.
Ex. 

```
show kafka-config
Command result: OK
myConfig1
myConfig2
```

Add a description of your changes here.

### Testing
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Coverage (>90%)

### Documentation
- [ ] Changelog update
- [ ] Documentation entry

### Scalastyle
Result of scalastyle execution: 
