### PR TITLE
Weighted generators

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,11 @@
             <version>${scala-logging.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.jliszka</groupId>
+            <artifactId>probability-monad_2.11</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -223,11 +223,6 @@
             <version>${scala-logging.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jliszka</groupId>
-            <artifactId>probability-monad_2.11</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.version}</version>

--- a/src/main/resources/web/js/console.js
+++ b/src/main/resources/web/js/console.js
@@ -136,7 +136,7 @@ function stop(term){
       term.pop();
     },
     {
-        prompt: 'khermes> start > Please introduce the node-Ids name> ',
+        prompt: 'khermes> stop > Please introduce the node-Ids name> ',
         name: 'stopNodeIds'});
 }
 

--- a/src/main/scala/com/stratio/khermes/cluster/supervisor/NodeSupervisorActor.scala
+++ b/src/main/scala/com/stratio/khermes/cluster/supervisor/NodeSupervisorActor.scala
@@ -22,7 +22,6 @@ import akka.actor.{Actor, ActorLogging}
 import akka.cluster.pubsub.{DistributedPubSub, DistributedPubSubMediator}
 import com.stratio.khermes.cluster.supervisor.NodeSupervisorActor.Result
 import com.stratio.khermes.commons.config.AppConfig
-import com.stratio.khermes.commons.constants.AppConstants
 import com.stratio.khermes.helpers.faker.Faker
 import com.stratio.khermes.helpers.twirl.TwirlHelper
 import com.stratio.khermes.persistence.kafka.KafkaClient
@@ -50,8 +49,7 @@ class NodeSupervisorActor(implicit config: Config) extends Actor with ActorLoggi
   val id = UUID.randomUUID.toString
 
   val khermes = Faker(Try(config.getString("khermes.i18n")).toOption.getOrElse("EN"),
-    AppConstants.DefaultStrategy)
-//    Try(config.getString("khermes.weightStrategy")).toOption.getOrElse("DefaultStrategy"))
+    Try(config.getString("khermes.strategy")).toOption)
 
   override def receive: Receive = {
     case NodeSupervisorActor.Start(ids, hc) =>
@@ -115,7 +113,7 @@ class NodeExecutorThread(hc: AppConfig)(implicit config: Config) extends NodeExe
     running = true
     val kafkaClient = new KafkaClient[Object](hc.kafkaConfig)
     val template = TwirlHelper.template[(Faker) => Txt](hc.templateContent, hc.templateName)
-    val khermes = Faker(hc.khermesI18n)
+    val khermes = Faker(hc.khermesI18n,hc.strategy)
 
     val parserOption = hc.avroSchema.map(new Parser().parse(_))
 

--- a/src/main/scala/com/stratio/khermes/cluster/supervisor/NodeSupervisorActor.scala
+++ b/src/main/scala/com/stratio/khermes/cluster/supervisor/NodeSupervisorActor.scala
@@ -22,6 +22,7 @@ import akka.actor.{Actor, ActorLogging}
 import akka.cluster.pubsub.{DistributedPubSub, DistributedPubSubMediator}
 import com.stratio.khermes.cluster.supervisor.NodeSupervisorActor.Result
 import com.stratio.khermes.commons.config.AppConfig
+import com.stratio.khermes.commons.constants.AppConstants
 import com.stratio.khermes.helpers.faker.Faker
 import com.stratio.khermes.helpers.twirl.TwirlHelper
 import com.stratio.khermes.persistence.kafka.KafkaClient
@@ -48,7 +49,9 @@ class NodeSupervisorActor(implicit config: Config) extends Actor with ActorLoggi
   var khermesExecutor: Option[NodeExecutorThread] = None
   val id = UUID.randomUUID.toString
 
-  val khermes = Faker(Try(config.getString("khermes.i18n")).toOption.getOrElse("EN"))
+  val khermes = Faker(Try(config.getString("khermes.i18n")).toOption.getOrElse("EN"),
+    AppConstants.DefaultStrategy)
+//    Try(config.getString("khermes.weightStrategy")).toOption.getOrElse("DefaultStrategy"))
 
   override def receive: Receive = {
     case NodeSupervisorActor.Start(ids, hc) =>

--- a/src/main/scala/com/stratio/khermes/cluster/supervisor/NodeSupervisorActor.scala
+++ b/src/main/scala/com/stratio/khermes/cluster/supervisor/NodeSupervisorActor.scala
@@ -113,7 +113,7 @@ class NodeExecutorThread(hc: AppConfig)(implicit config: Config) extends NodeExe
     running = true
     val kafkaClient = new KafkaClient[Object](hc.kafkaConfig)
     val template = TwirlHelper.template[(Faker) => Txt](hc.templateContent, hc.templateName)
-    val khermes = Faker(hc.khermesI18n,hc.strategy)
+    val khermes = Faker(hc.khermesI18n, hc.strategy)
 
     val parserOption = hc.avroSchema.map(new Parser().parse(_))
 

--- a/src/main/scala/com/stratio/khermes/commons/config/AppConfig.scala
+++ b/src/main/scala/com/stratio/khermes/commons/config/AppConfig.scala
@@ -72,6 +72,8 @@ case class AppConfig(khermesConfigContent: String,
 
   def khermesI18n: String = khermesConfig.getString("khermes.i18n")
 
+  def strategy: Option[String] = Try(khermesConfig.getString("khermes.strategy")).toOption
+
   def timeoutNumberOfEventsOption: Option[Int] = Try(khermesConfig.getInt("khermes.timeout-rules.number-of-events")).toOption
 
   def timeoutNumberOfEventsDurationOption: Option[Duration] = Try(khermesConfig.getDuration("khermes.timeout-rules.duration")).toOption

--- a/src/main/scala/com/stratio/khermes/commons/constants/AppConstants.scala
+++ b/src/main/scala/com/stratio/khermes/commons/constants/AppConstants.scala
@@ -76,5 +76,5 @@ object AppConstants {
   val DefaultWSHost = "localhost"
   val DefaultWSPort = 8080
 
-  val DefaultStrategy = Map("Gonzalo" ->0.8)
+  val DefaultStrategy = Option("default")
 }

--- a/src/main/scala/com/stratio/khermes/commons/constants/AppConstants.scala
+++ b/src/main/scala/com/stratio/khermes/commons/constants/AppConstants.scala
@@ -75,4 +75,6 @@ object AppConstants {
 
   val DefaultWSHost = "localhost"
   val DefaultWSPort = 8080
+
+  val DefaultStrategy = Map("Gonzalo" ->0.8)
 }

--- a/src/main/scala/com/stratio/khermes/helpers/faker/Faker.scala
+++ b/src/main/scala/com/stratio/khermes/helpers/faker/Faker.scala
@@ -27,8 +27,8 @@ import org.json4s.native.Serialization._
 import scala.util.{Failure, Random, Success, Try}
 
 /**
- * Khermes util used for to generate random values.
- */
+  * Khermes util used for to generate random values.
+  */
 case class Faker(locale: String = AppConstants.DefaultLocale, strategy: Option[String] = None) extends AppSerializer {
 
   object Name extends NameGenerator(locale, strategy)
@@ -50,26 +50,29 @@ trait FakerGenerator extends AppSerializer {
   def name: String
 
   /**
-   * Returns a random element from a list.
-   * @param list initial list
-   * @tparam T with the type of the list
-   * @return a random element of the list or None if the list is empty.
-   */
+    * Returns a random element from a list.
+    *
+    * @param list initial list
+    * @tparam T with the type of the list
+    * @return a random element of the list or None if the list is empty.
+    */
   def randomElementFromAList[T](list: Seq[T]): Option[T] =
-    if (list.nonEmpty) Option(list(Random.nextInt((list.size - 1) + 1))) else None
+  if (list.nonEmpty) Option(list(Random.nextInt((list.size - 1) + 1))) else None
 
   //TODO: We should provide more strategies.
   def listWithStrategy[T](list: Seq[T], strategy: String): Seq[(T, Double)] = {
-    var p = 0.0
     strategy match {
-      case "default" => p = 0.8
-      case _ => p =0.5
+      case "default" => listStrategyApply(list, 0.8)
+      case _ => listStrategyApply(list, 0.5)
     }
+  }
+
+  def listStrategyApply[T](list: Seq[T], p: Double): Seq[(T, Double)] = {
     val first: (T, Double) = list.head -> p
     val tail: Seq[(T, Double)] = list.tail.map(x =>
-      x -> ((1 - p)/(list.size - 1))
+      x -> ((1 - p) / (list.size - 1))
     )
-    tail:+first
+    tail :+ first
   }
 
 

--- a/src/main/scala/com/stratio/khermes/helpers/faker/generators/NameGenerator.scala
+++ b/src/main/scala/com/stratio/khermes/helpers/faker/generators/NameGenerator.scala
@@ -24,7 +24,7 @@ import com.typesafe.scalalogging.LazyLogging
 /**
  * Generates random names.
  */
-case class NameGenerator(locale: String, weightStrategy: Map[String, Double]) extends FakerGenerator
+case class NameGenerator(locale: String, strategy: Option[String]) extends FakerGenerator
   with AppSerializer
   with LazyLogging {
 
@@ -33,14 +33,35 @@ case class NameGenerator(locale: String, weightStrategy: Map[String, Double]) ex
   lazy val nameModel: Seq[Either[String, NameModel]] = locale match {
     case AppConstants.DefaultLocale =>
       val resources = getResources(name)
-        .map(parse[NameModel](name, _))
-      if (parseErrors[NameModel](resources).nonEmpty) logger.warn(s"${parseErrors[NameModel](resources)}")
-      resources
-    case localeValue => Seq(parse[NameModel](name, s"$localeValue.json").right.map(elem =>
-      NameModel(repeatElementsInList(listWithWeight(elem.firstNames, weightStrategy)), repeatElementsInList(listWithWeight(elem.lastNames, weightStrategy)))
-    ))
-    //    case localeValue => repeatElementsInList(listWithWeight(Seq(parse[NameModel](name, s"$localeValue.json")),weightStrategy))
+      if (strategy.isDefined) {
+        val res = resources.map(parse[NameModel](name, _)
+          .right.map(elem =>
+          NameModel(
+            repeatElementsInList(listWithStrategy(elem.firstNames, strategy.getOrElse(throw new IllegalArgumentException("Bad strategy definition"))))
+            , repeatElementsInList(listWithStrategy(elem.lastNames, strategy.getOrElse(throw new IllegalArgumentException("Bad strategy definition")))))
+        ))
+        if (parseErrors[NameModel](res).nonEmpty) logger.warn(s"${parseErrors[NameModel](res)}")
+        res
+      }
+      else {
+        val res = resources.map(parse[NameModel](name, _))
+        if (parseErrors[NameModel](res).nonEmpty) logger.warn(s"${parseErrors[NameModel](res)}")
+        res
+      }
+    case localeValue =>
+      if (strategy.isDefined) {
+        Seq(parse[NameModel](name, s"$localeValue.json")
+          .right.map(elem =>
+          NameModel(repeatElementsInList(listWithStrategy(elem.firstNames, strategy.getOrElse(throw new IllegalArgumentException("Bad strategy definition")))),
+            repeatElementsInList(listWithStrategy(elem.lastNames, strategy.getOrElse(throw new IllegalArgumentException("Bad strategy definition"))))))
+        )
+      } else {
+        Seq(parse[NameModel](name, s"$localeValue.json"))
+      }
   }
+
+  lazy val fisrtNameModel = firstNames(nameModel)
+  lazy val lastNameModel = lastNames(nameModel)
 
   /**
    * Example: "Bruce Wayne".
@@ -59,7 +80,7 @@ case class NameGenerator(locale: String, weightStrategy: Map[String, Double]) ex
    * @return a first name.
    */
   def firstName(): String =
-    randomElementFromAList[String](firstNames(nameModel)).getOrElse(throw new NoSuchElementException)
+  randomElementFromAList[String](fisrtNameModel).getOrElse(throw new NoSuchElementException)
 
 
   /**
@@ -67,7 +88,7 @@ case class NameGenerator(locale: String, weightStrategy: Map[String, Double]) ex
    * @return a last name.
    */
   def lastName(): String =
-    randomElementFromAList[String](lastNames(nameModel)).getOrElse(throw new NoSuchElementException)
+  randomElementFromAList[String](lastNameModel).getOrElse(throw new NoSuchElementException)
 
   def lastNames(resources: Seq[Either[String, NameModel]]): Seq[String] = {
     getName(resources: Seq[Either[String, NameModel]]).flatMap(_.firstNames)

--- a/src/main/scala/com/stratio/khermes/helpers/faker/generators/NameGenerator.scala
+++ b/src/main/scala/com/stratio/khermes/helpers/faker/generators/NameGenerator.scala
@@ -42,8 +42,7 @@ case class NameGenerator(locale: String, strategy: Option[String]) extends Faker
         ))
         if (parseErrors[NameModel](res).nonEmpty) logger.warn(s"${parseErrors[NameModel](res)}")
         res
-      }
-      else {
+      } else {
         val res = resources.map(parse[NameModel](name, _))
         if (parseErrors[NameModel](res).nonEmpty) logger.warn(s"${parseErrors[NameModel](res)}")
         res
@@ -60,8 +59,6 @@ case class NameGenerator(locale: String, strategy: Option[String]) extends Faker
       }
   }
 
-  lazy val fisrtNameModel = firstNames(nameModel)
-  lazy val lastNameModel = lastNames(nameModel)
 
   /**
    * Example: "Bruce Wayne".
@@ -80,7 +77,7 @@ case class NameGenerator(locale: String, strategy: Option[String]) extends Faker
    * @return a first name.
    */
   def firstName(): String =
-  randomElementFromAList[String](fisrtNameModel).getOrElse(throw new NoSuchElementException)
+  randomElementFromAList[String](firstNames(nameModel)).getOrElse(throw new NoSuchElementException)
 
 
   /**
@@ -88,7 +85,7 @@ case class NameGenerator(locale: String, strategy: Option[String]) extends Faker
    * @return a last name.
    */
   def lastName(): String =
-  randomElementFromAList[String](lastNameModel).getOrElse(throw new NoSuchElementException)
+  randomElementFromAList[String](lastNames(nameModel)).getOrElse(throw new NoSuchElementException)
 
   def lastNames(resources: Seq[Either[String, NameModel]]): Seq[String] = {
     getName(resources: Seq[Either[String, NameModel]]).flatMap(_.firstNames)

--- a/src/test/scala/com/stratio/khermes/helpers/faker/FakerGeneratorTest.scala
+++ b/src/test/scala/com/stratio/khermes/helpers/faker/FakerGeneratorTest.scala
@@ -78,4 +78,11 @@ class FakerGeneratorTest extends FlatSpec with FakerGenerator with Matchers with
       getResource("no-valid-name", "EN.json")
     }
   }
+
+
+  it should "return always the same value of a list if have a weight of 1" in {
+//    randomElementFromAList(Seq(0, 1, 2), Map(0 -> 1.0)) shouldBe Some(0)
+
+  }
+
 }

--- a/src/test/scala/com/stratio/khermes/helpers/faker/FakerGeneratorTest.scala
+++ b/src/test/scala/com/stratio/khermes/helpers/faker/FakerGeneratorTest.scala
@@ -79,10 +79,4 @@ class FakerGeneratorTest extends FlatSpec with FakerGenerator with Matchers with
     }
   }
 
-
-  it should "return always the same value of a list if have a weight of 1" in {
-//    randomElementFromAList(Seq(0, 1, 2), Map(0 -> 1.0)) shouldBe Some(0)
-
-  }
-
 }

--- a/src/test/scala/com/stratio/khermes/helpers/faker/generators/NameGeneratorTest.scala
+++ b/src/test/scala/com/stratio/khermes/helpers/faker/generators/NameGeneratorTest.scala
@@ -28,15 +28,7 @@ class NameGeneratorTest extends FlatSpec
   with Matchers {
 
 
-  "A Khermes" should "generates random firstNames and lastNames with EN and ES locales" in {
-    val khermesEN = Faker()
-    khermesEN.Name.firstNames(khermesEN.Name.nameModel) should contain(khermesEN.Name.firstName)
-    khermesEN.Name.lastNames(khermesEN.Name.nameModel) should contain(khermesEN.Name.lastName)
 
-    val khermesES = Faker("ES")
-    khermesES.Name.firstNames(khermesEN.Name.nameModel) should contain(khermesES.Name.firstName)
-    khermesES.Name.lastNames(khermesEN.Name.nameModel) should contain(khermesES.Name.lastName)
-  }
 
   it should "generate valid names: firstName lastName with EN and ES locales" in {
     val khermesEN = Faker()
@@ -79,5 +71,24 @@ class NameGeneratorTest extends FlatSpec
     val model = Faker("XY").Name.nameModel
     //scalastyle:on
     model.map(_.left.get should equal(s"Error loading invalid resource /locales/name/XY.json"))
+  }
+
+  "A Khermes" should "generates random firstNames and lastNames with EN and ES locales" in {
+    val khermesEN = Faker()
+    khermesEN.Name.firstNames(khermesEN.Name.nameModel) should contain(khermesEN.Name.firstName)
+    khermesEN.Name.lastNames(khermesEN.Name.nameModel) should contain(khermesEN.Name.lastName)
+
+    val khermesES = Faker("ES")
+    khermesES.Name.firstNames(khermesEN.Name.nameModel) should contain(khermesES.Name.firstName)
+    khermesES.Name.lastNames(khermesEN.Name.nameModel) should contain(khermesES.Name.lastName)
+  }
+  "A Khermes" should "generates random firstNames and lastNames with EN and ES locales with weight" in {
+    val khermesEN = Faker()
+    khermesEN.Name.firstNames(khermesEN.Name.nameModel) should contain(khermesEN.Name.firstName())
+    khermesEN.Name.lastNames(khermesEN.Name.nameModel) should contain(khermesEN.Name.lastName)
+
+    val khermesES = Faker("ES")
+    khermesES.Name.firstNames(khermesEN.Name.nameModel) should contain(khermesEN.Name.firstName())
+    khermesES.Name.lastNames(khermesEN.Name.nameModel) should contain(khermesES.Name.lastName)
   }
 }

--- a/src/test/scala/com/stratio/khermes/helpers/faker/generators/NameGeneratorTest.scala
+++ b/src/test/scala/com/stratio/khermes/helpers/faker/generators/NameGeneratorTest.scala
@@ -82,13 +82,5 @@ class NameGeneratorTest extends FlatSpec
     khermesES.Name.firstNames(khermesEN.Name.nameModel) should contain(khermesES.Name.firstName)
     khermesES.Name.lastNames(khermesEN.Name.nameModel) should contain(khermesES.Name.lastName)
   }
-  "A Khermes" should "generates random firstNames and lastNames with EN and ES locales with weight" in {
-    val khermesEN = Faker()
-    khermesEN.Name.firstNames(khermesEN.Name.nameModel) should contain(khermesEN.Name.firstName())
-    khermesEN.Name.lastNames(khermesEN.Name.nameModel) should contain(khermesEN.Name.lastName)
 
-    val khermesES = Faker("ES")
-    khermesES.Name.firstNames(khermesEN.Name.nameModel) should contain(khermesEN.Name.firstName())
-    khermesES.Name.lastNames(khermesEN.Name.nameModel) should contain(khermesES.Name.lastName)
-  }
 }


### PR DESCRIPTION
## Description
- Now you can pass a khermes.strategy to define a weihgt in the generation of names at the moment.
- The "default" give the first element in a list a probabily of 80% and split the 20% for the rest of elements.
- Precalculate the list only one time in the name generator (we should make that in all generators)
Add a description of your changes here.

### Testing
- [ ] Unit, integration, acceptance tests as appropriate
- [ ] Coverage (>90%)

### Documentation
- [ ] Changelog update
- [ ] Documentation entry

### Scalastyle
Result of scalastyle execution: 
